### PR TITLE
Better API for adding buttons to form

### DIFF
--- a/Gopay/Extension.php
+++ b/Gopay/Extension.php
@@ -62,4 +62,14 @@ class Extension extends CompilerExtension
 		}
 	}
 
+
+
+	public function afterCompile(ClassType $class)
+	{
+		$initialize = $class->methods['initialize'];
+		$initialize->addBody('Markette\Gopay\Service::registerAddPaymentButtons($this->getService(?));', array(
+			$this->prefix('service'),
+		));
+	}
+
 }

--- a/Gopay/Service.php
+++ b/Gopay/Service.php
@@ -538,4 +538,21 @@ class Service extends Nette\Object
 		);
 	}
 
+
+
+	/**
+	 * Registers 'addPaymentButtons' & 'addPaymentButton' methods to form
+	 *
+	 * @param  Service
+	 */
+	public static function registerAddPaymentButtons(Service $service)
+	{
+		Nette\Forms\Container::registerMethod('addPaymentButtons', function ($container, $callbacks) use ($service) {
+			$service->bindPaymentButtons($container, $callbacks);
+		});
+		Nette\Forms\Container::registerMethod('addPaymentButton', function ($container, $channel) use ($service) {
+			return $service->bindPaymentButton($channel, $container);
+		});
+	}
+
 }


### PR DESCRIPTION
Allows following syntax:

``` php
$form->addPaymentButtons(array(
   $this->processForm,
));
```

Or even:

``` php
use Markette\Gopay;

$form->addPaymentButton(Gopay\Service::METHOD_GOPAY)
    ->onClick[] = $this->processGopayMethod;
```
