### PR TITLE
Removed short array syntax

### DIFF
--- a/Gopay/Extension.php
+++ b/Gopay/Extension.php
@@ -48,7 +48,7 @@ class Extension extends CompilerExtension
 					$channel = $constants->getConstant($constChannel);
 				}
 				if (is_bool($value)) {
-					$service->addSetup($value ? 'allowChannel' : 'denyChannel', [$channel]);
+					$service->addSetup($value ? 'allowChannel' : 'denyChannel', array($channel));
 				} elseif (is_array($value)) {
 					$title = $value['title'];
 					unset($value['title']);


### PR DESCRIPTION
composer.json says that the project requires php version >=5.3.2, but it in fact requires 5.4, due to the usage of short array syntax.
